### PR TITLE
Fix variable name

### DIFF
--- a/scripts/perl.prov
+++ b/scripts/perl.prov
@@ -86,7 +86,7 @@ foreach $module (sort keys %require) {
     # $RPM_* variable when I upgrade.
 
     my $normv = version->parse($require{$module})->normal;
-    $v =~ s/^v//;
+    $normv =~ s/^v//;
     if($normalversion)
     {
       print "perl($module) = $normv\n";


### PR DESCRIPTION
This wasn't detected because of missing strict and warnings.
I would like to add them, but I don't want to break anything. I think adding code coverage would be good at some point.
I hope I can have a look at that...