### PR TITLE
Add unit tests for perl.prov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,12 +8,58 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        perl-version:
+        - '5.8-buster'
+        - '5.10-buster'
+        - '5.12-buster'
+        - '5.14-buster'
+        - '5.16-buster'
+        - '5.18-buster'
+        - '5.20-buster'
+        - '5.22-buster'
+        - '5.24-buster'
+        - '5.26-buster'
+        - '5.28-buster'
+        - '5.30-bullseye'
+        - '5.32-bullseye'
+        - '5.34-bullseye'
+        - '5.36-bookworm'
+        - '5.38-bookworm'
+        - '5.40-bookworm'
+        - 'latest'
+
+    container:
+      image: perl:${{ matrix.perl-version }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run tests
+      run: |
+        cpanm -n Test::More
+        perl -c scripts/perl.req
+        make testv
+
+
+  coverage:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
-    - name: Check
+    - name: Dependencies
       run: |
-        perl -c scripts/perl.prov
+        sudo apt-get install -y libdevel-cover-perl
+    - name: Check Coverage
+      run: |
         perl -c scripts/perl.req
+        make cover
+        rc=0
+        cover | grep ^Total | grep '100.0$' || rc=1
+        if [[ $rc -ne 0 ]]; then
+            echo "Coverage should be 100%"
+            exit 1
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/cover_db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+test:
+	prove t
+
+testv:
+	prove -v t
+
+cover:
+	PERL5OPT=-MDevel::Cover=+ignore,/usr/bin/prove prove t/ && cover
+
+clean:
+	rm -rf cover_db
+

--- a/scripts/perl.prov
+++ b/scripts/perl.prov
@@ -245,7 +245,7 @@ sub process_file {
 	  die "Unclosed HEREDOC [$inheredoc] in file: '$file'\n";
   }
 
-  close(FILE) ||
+  close(FILE) ||  # uncoverable branch true
     die("$0: Could not close file: '$file' : $!\n");
 
   return;

--- a/t/10.basic-prov.t
+++ b/t/10.basic-prov.t
@@ -1,0 +1,41 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin '$Bin';
+
+# TODO only execute version->parse if flag is used
+if ($] < 5.010) { # uncoverable branch true
+    plan skip_all => 'Perl < v5.8 does not have version.pm'; # uncoverable statement
+}
+
+my $prov = "$Bin/../scripts/perl.prov";
+my $data = "$Bin/data";
+
+subtest basic => sub {
+    my $exp = <<'EOM';
+perl(Example::Module) = 3.14159
+EOM
+
+    my $out = qx{find $data/basic | $^X $prov};
+    is $out, $exp, 'perl.prov (STDIN) output as expected';
+
+    chomp(my @files = qx{find $data/basic});
+    $out = qx{$^X $prov @files};
+    is $out, $exp, 'perl.prov (@ARGV) output as expected';
+};
+
+subtest errors => sub {
+    my $out = qx{$^X $prov $data/some/nonexistant/file.pm 2>&1};
+    my $rc = $?;
+    is $rc, 0, 'Missing file still exits with 0';
+    like $out, qr{Could not open file.*for reading}, 'Warning about missing file';
+
+    $out = qx{$^X $prov $data/broken/Module1.pm 2>&1};
+    $rc = $? >> 8;
+    is $rc, 255, 'Broken heredoc exits with 255';
+    like $out, qr{Unclosed HEREDOC \[EOM\] in.*Module1.pm}, 'Error about broken heredoc';
+};
+
+
+done_testing;

--- a/t/11.variants-prov.t
+++ b/t/11.variants-prov.t
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin '$Bin';
+
+# TODO only execute version->parse if flag is used
+if ($] < 5.010) { # uncoverable branch true
+    plan skip_all => 'Perl < v5.8 does not have version.pm'; # uncoverable statement
+}
+
+my $prov = "$Bin/../scripts/perl.prov";
+my $data = "$Bin/data";
+
+my $exp = <<'EOM';
+Extra1
+Extra2::Module
+perl(Example1) = 1.1
+perl(Example10) = 1.10
+perl(Example11)
+perl(Example12) = 1.12
+perl(Example13) = 1.13
+perl(Example14) = 1.14
+perl(Example15) = 1.15
+perl(Example2) = 1.2
+perl(Example3) = 1.3
+perl(Example4) = 1.4
+perl(Example5) = 1.5
+perl(Example6) = 1.6
+perl(Example7) = 1.7
+perl(Example8) = 1.8
+perl(Example9) = 1.9
+EOM
+
+chomp(my @files = qx{find $data/variants});
+
+my $out = qx{$^X $prov @files};
+is $out, $exp, 'perl.prov (@ARGV) output as expected';
+
+done_testing;

--- a/t/12.versions-prov.t
+++ b/t/12.versions-prov.t
@@ -1,0 +1,91 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin '$Bin';
+
+# TODO only execute version->parse if flag is used
+if ($] < 5.010) { # uncoverable branch true
+    plan skip_all => 'Perl < v5.8 does not have version.pm'; # uncoverable statement
+}
+
+my $prov = "$Bin/../scripts/perl.prov";
+my $data = "$Bin/data";
+
+my $exp = <<'EOM';
+perl(Example1) = 1.0
+perl(Example2) = 3.14159
+perl(Example3) = 3.14
+perl(Example4) = 3.14
+perl(Example5)
+EOM
+
+my $exp_normal = <<'EOM';
+perl(Example1) = 1.0.0
+perl(Example2) = 3.141.590
+perl(Example3) = 3.140.0
+perl(Example4) = 3.140.0
+perl(Example5)
+EOM
+
+my $exp_perln = <<'EOM';
+perl(Example1) = 1.0
+perln(Example1) = 1.0.0
+perl(Example2) = 3.14159
+perln(Example2) = 3.141.590
+perl(Example3) = 3.14
+perln(Example3) = 3.140.0
+perl(Example4) = 3.14
+perln(Example4) = 3.140.0
+perl(Example5)
+perln(Example5)
+EOM
+
+my $file1 = "$data/versions/Module.pm";
+subtest various => sub {
+
+    my $out = qx{$^X $prov $file1};
+    is $out, $exp, 'perl.prov decimal versions as expected';
+};
+
+subtest normalize => sub {
+    my $out = qx{$^X $prov --normalversion $file1};
+    is $out, $exp_normal, 'perl.prov --normalversion as expected';
+
+    $out = qx{$^X $prov --perln $file1};
+    is $out, $exp_perln, 'perl.prov --normalversion as expected';
+};
+
+subtest other => sub {
+
+    my $file2 = "$data/versions/Other.pm";
+
+    $exp = <<'EOM';
+perl(Example1) = 3.141_59
+EOM
+
+    $exp_normal = <<'EOM';
+perl(Example1) = 3.141.590
+EOM
+
+    $exp_perln = <<'EOM';
+perl(Example1) = 3.141_59
+perln(Example1) = 3.141.590
+EOM
+
+    my $out = qx{$^X $prov $file2};
+    is $out, $exp, 'perl.prov decimal versions as expected';
+
+    subtest 'underscore normalize' => sub {
+        if ($^V < v5.24) { # uncoverable branch true
+            plan skip_all => 'Perl < v5.24 normalizes versions with underscores differently'; # uncoverable statement
+        }
+        $out = qx{$^X $prov --normalversion $file2};
+        is $out, $exp_normal, 'perl.prov --normalversion as expected';
+
+        $out = qx{$^X $prov --perln $file2};
+        is $out, $exp_perln, 'perl.prov --normalversion as expected';
+    };
+};
+
+done_testing;

--- a/t/data/basic/Module.pm
+++ b/t/data/basic/Module.pm
@@ -1,0 +1,5 @@
+package Example::Module;
+
+our $VERSION = 3.14159;
+
+1;

--- a/t/data/broken/Module1.pm
+++ b/t/data/broken/Module1.pm
@@ -1,0 +1,3 @@
+package Example1;
+
+my $here = <<"EOM";

--- a/t/data/variants/Module.pm
+++ b/t/data/variants/Module.pm
@@ -1,0 +1,120 @@
+package Example1;
+
+our $VERSION = 1.1;
+
+=pod
+
+=encoding utf-8
+
+=head1 NAME
+
+YAML::PP - YAML 1.2 processor
+
+our $VERSION = 11;
+
+=cut
+
+
+
+package Example2;
+
+our $VERSION = 1.2;
+
+=head1 DESCRIPTION
+
+our $VERSION = 12;
+
+=cut
+
+
+
+package Example3;
+
+our $VERSION = 1.3;
+
+=over
+
+our $VERSION = 13;
+
+=cut
+
+package Example4;
+
+our $VERSION = 1.4;
+
+=item one
+
+our $VERSION = 14;
+
+=item two
+
+our $VERSION = 15;
+
+=back
+
+=cut
+
+package Example5;
+our $VERSION = 1.5;
+
+# TODO support bare heredocs
+# my $here1 = <<EOM;
+# our $VERSION = 17;
+#EOM
+
+my $here2 = <<'EOM2';
+our $VERSION = 18;
+EOM2
+
+package Example6;
+
+our $VERSION = 1.6;
+our $VERSION = 19; # NO_RPM_PERL_PROVIDES
+
+package Example7;
+
+our $VERSION = 1.7;
+
+ # our $VERSION = 8;
+
+package main;
+our $VERSION = 3.14;
+
+package Example8;
+
+# note perl.prov does it wrong because printf would make it 1.008
+our $VERSION = sprintf '%d.%03d', q$Revision: 1.8 $ =~ /: (\d+).(\d+)/;
+
+our $RPM_Provides = "Extra1 Extra2::Module";
+
+package Example9 1.9 { }
+
+package Example10;
+our $VERSION = '1.10';
+
+package Example9 9.99 {
+# Previous 1.9 should win
+}
+
+package Example11;
+our $VERSION = 'not a number';
+
+package Example12;
+$Example12::VERSION = 1.12;
+
+package Example13;
+$VERSION = $VERSION = 1.13;
+
+package Example14;
+our $VERSION = "1.14";
+
+package Example15;
+our $VERSION = '1.15';
+
+1;
+
+__DATA__
+
+package Data;
+
+our $VERSION = 3.14;

--- a/t/data/versions/Module.pm
+++ b/t/data/versions/Module.pm
@@ -1,0 +1,17 @@
+package Example1;
+our $VERSION = 1.0;
+
+package Example2;
+our $VERSION = 3.14159;
+
+# TODO
+#package Example;
+#our $VERSION = v3.14;
+
+package Example3 3.14 { }
+
+package Example4 v3.14 { }
+
+package Example5;
+
+1;

--- a/t/data/versions/Other.pm
+++ b/t/data/versions/Other.pm
@@ -1,0 +1,4 @@
+package Example1;
+our $VERSION = 3.141_59;
+
+1;


### PR DESCRIPTION
This adds unit tests to achieve 100% coverage for perl.prov.

I didn't want to introduce any changes in perl.prov at this point so
I added some todos:
* The code doesn't work on perl 5.8 anymore because it doesn't have version.pm.
  I think it can be fixed by moving the version->parse thing into the branch
  where the actual commandline option is used. Not sure which old perl
  versions we have to support, but 5.8 should be easy to support, and
  it might be possible someone would want to run the latest rpm on a machine
  with perl 5.8
* Bare <<EOM tags are not supported yet
* Versions with a single digit aren't supported (`\d+[._0-9]+`)

It runs the unit tests on all perl versions, and runs the coverage in an extra job and checks for 100%.
I had to mark one line as uncoverable.