### PR TITLE
Make code work on perl v5.18 again

### DIFF
--- a/scripts/perl.prov
+++ b/scripts/perl.prov
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+use strict;
 
 # RPM (and it's source code) is covered under two separate licenses.
 
@@ -47,6 +48,7 @@
 
 my $normalversion = 0;
 my $perln = 0;
+my %require;
 
 while ("@ARGV") {
   if ($ARGV[0] =~ /^--/) {
@@ -75,7 +77,7 @@ if ("@ARGV") {
 }
 
 
-foreach $module (sort keys %require) {
+foreach my $module (sort keys %require) {
   if (length($require{$module}) == 0) {
     print "perl($module)\n";
     print "perln($module)\n" if $perln;

--- a/scripts/perl.prov
+++ b/scripts/perl.prov
@@ -48,7 +48,7 @@ use strict;
 
 my $normalversion = 0;
 my $perln = 0;
-my %require;
+my %provides;
 
 while ("@ARGV") {
   if ($ARGV[0] =~ /^--/) {
@@ -77,8 +77,8 @@ if ("@ARGV") {
 }
 
 
-foreach my $module (sort keys %require) {
-  if (length($require{$module}) == 0) {
+foreach my $module (sort keys %provides) {
+  if (length($provides{$module}) == 0) {
     print "perl($module)\n";
     print "perln($module)\n" if $perln;
   } else {
@@ -88,14 +88,14 @@ foreach my $module (sort keys %require) {
     # $RPM_* variable when I upgrade.
 
     if ($normalversion) {
-      my $normv = normalversion($require{$module});
+      my $normv = normalversion($provides{$module});
       print "perl($module) = $normv\n";
     }
     else {
-      print "perl($module) = $require{$module}\n";
+      print "perl($module) = $provides{$module}\n";
     }
     if ($perln) {
-      my $normv = normalversion($require{$module});
+      my $normv = normalversion($provides{$module});
       print "perln($module) = $normv\n";
     }
   }
@@ -187,11 +187,11 @@ sub process_file {
       if ($package eq 'main') {
         undef $package;
       } else {
-        # If $package already exists in the $require hash, it means
+        # If $package already exists in the %provides hash, it means
         # the package definition is broken up over multiple blocks.
         # In that case, don't stomp a previous $VERSION we might have
         # found.  (See BZ#214496.)
-        $require{$package} = $version unless (exists $require{$package});
+        $provides{$package} = $version unless (exists $provides{$package});
       }
     }
 
@@ -224,7 +224,7 @@ sub process_file {
 
         $version = $1;
       }
-      $require{$package} = $version;
+      $provides{$package} = $version;
     }
 
     # Allow someone to have a variable that defines virtual packages

--- a/scripts/perl.prov
+++ b/scripts/perl.prov
@@ -85,22 +85,28 @@ foreach $module (sort keys %require) {
     # operators. Also I will need to change the processing of the
     # $RPM_* variable when I upgrade.
 
-    my $normv = version->parse($require{$module})->normal;
-    $normv =~ s/^v//;
-    if($normalversion)
-    {
+    if ($normalversion) {
+      my $normv = normalversion($require{$module});
       print "perl($module) = $normv\n";
     }
-    else
-    {
+    else {
       print "perl($module) = $require{$module}\n";
     }
-    print "perln($module) = $normv\n" if $perln;
+    if ($perln) {
+      my $normv = normalversion($require{$module});
+      print "perln($module) = $normv\n";
+    }
   }
 }
 
 exit 0;
 
+sub normalversion {
+    my ($version) = @_;
+    my $normalized = version->parse($version)->normal;
+    $normalized =~ s/^v//;
+    return $normalized;
+}
 
 
 sub process_file {

--- a/scripts/perl.req
+++ b/scripts/perl.req
@@ -84,22 +84,29 @@ foreach $module (sort keys %require) {
     # operators. Also I will need to change the processing of the
     # $RPM_* variable when I upgrade.
 
-    my $normv = version->parse($require{$module})->normal;
-    $normv =~ s/^v//;
-    if($normalversion)
-    {
+    if ($normalversion) {
+      my $normv = normalversion($require{$module});
       print "perl($module) = $normv\n";
     }
     else
     {
       print "perl($module) = $require{$module}\n";
     }
-    print "perln($module) = $normv\n" if $perln;
+    if ($perln) {
+      my $normv = normalversion($require{$module});
+      print "perln($module) = $normv\n";
+    }
   }
 }
 
 exit 0;
 
+sub normalversion {
+    my ($version) = @_;
+    my $normalized = version->parse($version)->normal;
+    $normalized =~ s/^v//;
+    return $normalized;
+}
 
 
 sub add_require {

--- a/t/10.basic-prov.t
+++ b/t/10.basic-prov.t
@@ -4,11 +4,6 @@ use warnings;
 use Test::More;
 use FindBin '$Bin';
 
-# TODO only execute version->parse if flag is used
-if ($] < 5.010) { # uncoverable branch true
-    plan skip_all => 'Perl < v5.8 does not have version.pm'; # uncoverable statement
-}
-
 my $prov = "$Bin/../scripts/perl.prov";
 my $data = "$Bin/data/prov";
 

--- a/t/10.basic-req.t
+++ b/t/10.basic-req.t
@@ -4,11 +4,6 @@ use warnings;
 use Test::More;
 use FindBin '$Bin';
 
-# TODO only execute version->parse if flag is used
-if ($] < 5.010) { # uncoverable branch true
-    plan skip_all => 'Perl < v5.8 does not have version.pm'; # uncoverable statement
-}
-
 my $req = "$Bin/../scripts/perl.req";
 my $data = "$Bin/data/req";
 
@@ -16,10 +11,14 @@ subtest basic => sub {
     my $exp = <<'EOM';
 perl(Example) = 3.15
 EOM
+    if ($] < 5.010) { # uncoverable branch true
+        # perl 5.18 does not have version.pm
+        $exp = <<'EOM'; # uncoverable statement
+perl(Example) = 3.14
+EOM
+    }
 
-    my $out = qx{find $data/basic -type f};
-    diag $out;
-    $out = qx{find $data/basic -type f | $^X $req};
+    my $out = qx{find $data/basic -type f | $^X $req};
     is $out, $exp, 'perl.req (STDIN) output as expected';
 
     chomp(my @files = qx{find $data/basic -type f});

--- a/t/11.variants-prov.t
+++ b/t/11.variants-prov.t
@@ -4,11 +4,6 @@ use warnings;
 use Test::More;
 use FindBin '$Bin';
 
-# TODO only execute version->parse if flag is used
-if ($] < 5.010) { # uncoverable branch true
-    plan skip_all => 'Perl < v5.8 does not have version.pm'; # uncoverable statement
-}
-
 my $prov = "$Bin/../scripts/perl.prov";
 my $data = "$Bin/data/prov";
 

--- a/t/11.variants-req.t
+++ b/t/11.variants-req.t
@@ -4,11 +4,6 @@ use warnings;
 use Test::More;
 use FindBin '$Bin';
 
-# TODO only execute version->parse if flag is used
-if ($] < 5.010) { # uncoverable branch true
-    plan skip_all => 'Perl < v5.8 does not have version.pm'; # uncoverable statement
-}
-
 my $req = "$Bin/../scripts/perl.req";
 my $data = "$Bin/data/req";
 

--- a/t/12.versions-prov.t
+++ b/t/12.versions-prov.t
@@ -4,10 +4,6 @@ use warnings;
 use Test::More;
 use FindBin '$Bin';
 
-# TODO only execute version->parse if flag is used
-if ($] < 5.010) { # uncoverable branch true
-    plan skip_all => 'Perl < v5.8 does not have version.pm'; # uncoverable statement
-}
 
 my $prov = "$Bin/../scripts/perl.prov";
 my $data = "$Bin/data/prov";
@@ -49,6 +45,9 @@ subtest various => sub {
 };
 
 subtest normalize => sub {
+    if ($] < 5.010) { # uncoverable branch true
+        plan skip_all => 'Perl v5.8 does not have version.pm'; # uncoverable statement
+    }
     my $out = qx{$^X $prov --normalversion $file1};
     is $out, $exp_normal, 'perl.prov --normalversion as expected';
 
@@ -77,7 +76,7 @@ EOM
     is $out, $exp, 'perl.prov decimal versions as expected';
 
     subtest 'underscore normalize' => sub {
-        if ($^V < v5.24) { # uncoverable branch true
+        if ($] < 5.024) { # uncoverable branch true
             plan skip_all => 'Perl < v5.24 normalizes versions with underscores differently'; # uncoverable statement
         }
         $out = qx{$^X $prov --normalversion $file2};

--- a/t/12.versions-req.t
+++ b/t/12.versions-req.t
@@ -4,10 +4,6 @@ use warnings;
 use Test::More;
 use FindBin '$Bin';
 
-# TODO only execute version->parse if flag is used
-if ($] < 5.010) { # uncoverable branch true
-    plan skip_all => 'Perl < v5.8 does not have version.pm'; # uncoverable statement
-}
 
 my $req = "$Bin/../scripts/perl.req";
 my $data = "$Bin/data/req";
@@ -41,6 +37,9 @@ subtest various => sub {
 };
 
 subtest normalize => sub {
+    if ($] < 5.010) { # uncoverable branch true
+        plan skip_all => 'Perl v5.8 does not have version.pm'; # uncoverable statement
+    }
     my $out = qx{$^X $req --normalversion $file1};
     is $out, $exp_normal, 'perl.req --normalversion as expected';
 

--- a/t/data/req/versions/Module.pm
+++ b/t/data/req/versions/Module.pm
@@ -4,6 +4,4 @@ use Example1;
 
 use Example2 3.14;
 
-use Example3 1.1;
 use Example3 1.2;
-use Example3 1.0;


### PR DESCRIPTION
5.18 did not have version.pm, so we use the code only when explicitly
specifying `--normalversion` or` --perln`

I also added `use strict` to perl.prov and renamed `%require` to `%provides`